### PR TITLE
partiel alert.scss modified to display correctly the banner alert message

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,6 +1,6 @@
 .alert {
   margin: 0;
-  position: absolute;
+  position: sticky;
   top: 50px;
   left: 0;
   width: 100%;
@@ -13,8 +13,8 @@
 .alert-dismissible .close {
   top: 0;
   right: 0;
-  padding: 0 52rem 0 800rem;
-  color: $gray-light;
+  padding: 0 58rem 0 800rem;
+  color: white;
   :hover {
   color: white;
   }


### PR DESCRIPTION
petites modifs pour afficher correctement la banner des messages d'alerte pour éviter overlapping.